### PR TITLE
Allow installing in PHP 8.2

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.3', '8.4', '8.5']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout code
@@ -42,7 +42,11 @@ jobs:
           ini-values: pcov.directory=.
 
       - name: Install dependencies
-        run: composer install ${{ matrix.php-versions == '8.5' && '--ignore-platform-reqs' || '' }}
+        run: |
+          if [ "${{ matrix.php-versions }}" == "8.2" ]; then
+            composer require --dev phpunit/phpunit:^11 --no-update
+          fi
+          composer install ${{ matrix.php-versions == '8.5' && '--ignore-platform-reqs' || '' }}
 
       - name: Validate composer.json
         run: |
@@ -54,11 +58,17 @@ jobs:
         continue-on-error: ${{ vars.CI_LINT_IGNORE_FAILURE == '1' }}
 
       - name: Run tests
-        run: composer test-coverage
+        run: |
+          if [ "${{ matrix.php-versions }}" != "8.2" ]; then
+            composer test-coverage
+          else
+            composer test
+          fi
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@v5
+        if: ${{ matrix.php-versions != '8.2' }}
         with:
           name: ${{github.job}}-code-coverage-report-${{ matrix.php-versions }}
           path: .logs
@@ -67,7 +77,7 @@ jobs:
 
       - name: Upload test results to Codecov
         uses: codecov/test-results-action@v1
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' && matrix.php-versions != '8.2' }}
         with:
           files: .logs/junit.xml
           fail_ci_if_error: true
@@ -76,7 +86,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ env.CODECOV_TOKEN != '' && matrix.php-versions != '8.2' }}
         with:
           files: .logs/cobertura.xml
           fail_ci_if_error: true

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/drevops/phpcs-standard"
     },
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^1",
         "squizlabs/php_codesniffer": "^3.10"
     },

--- a/src/DrevOps/Sniffs/NamingConventions/LocalVariableSnakeCaseSniff.php
+++ b/src/DrevOps/Sniffs/NamingConventions/LocalVariableSnakeCaseSniff.php
@@ -17,7 +17,7 @@ final class LocalVariableSnakeCaseSniff extends AbstractSnakeCaseSniff {
   /**
    * Error code for non-snake_case variables.
    */
-  public const string CODE_VARIABLE_NOT_SNAKE_CASE = 'NotSnakeCase';
+  public const CODE_VARIABLE_NOT_SNAKE_CASE = 'NotSnakeCase';
 
   /**
    * {@inheritdoc}

--- a/src/DrevOps/Sniffs/NamingConventions/ParameterSnakeCaseSniff.php
+++ b/src/DrevOps/Sniffs/NamingConventions/ParameterSnakeCaseSniff.php
@@ -18,7 +18,7 @@ final class ParameterSnakeCaseSniff extends AbstractSnakeCaseSniff {
   /**
    * Error code for non-snake_case parameters.
    */
-  public const string CODE_PARAMETER_NOT_SNAKE_CASE = 'NotSnakeCase';
+  public const CODE_PARAMETER_NOT_SNAKE_CASE = 'NotSnakeCase';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for PHP 8.2 and lowered the minimum PHP requirement to 8.2.
  * Adjusted CI to run tests on PHP 8.2 and to change install/test steps and coverage uploads depending on PHP version.
  * Downgraded development PHPUnit constraint and updated related CI steps.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->