### PR TITLE
[#13] Fixed nullable class properties incorrectly triggering `LocalVariableNaming.NotSnakeCase`.

### DIFF
--- a/src/DrevOps/Sniffs/NamingConventions/AbstractVariableNamingSniff.php
+++ b/src/DrevOps/Sniffs/NamingConventions/AbstractVariableNamingSniff.php
@@ -311,6 +311,10 @@ abstract class AbstractVariableNamingSniff implements Sniff {
         T_TYPE_INTERSECTION,
         T_ATTRIBUTE,
         T_ATTRIBUTE_END,
+        // PHP 8+ namespaced type tokens.
+        T_NAME_FULLY_QUALIFIED,
+        T_NAME_QUALIFIED,
+        T_NAME_RELATIVE,
       ],
       $stackPtr - 1,
       NULL,
@@ -401,6 +405,10 @@ abstract class AbstractVariableNamingSniff implements Sniff {
         T_TYPE_INTERSECTION,
         T_ATTRIBUTE,
         T_ATTRIBUTE_END,
+        // PHP 8+ namespaced type tokens.
+        T_NAME_FULLY_QUALIFIED,
+        T_NAME_QUALIFIED,
+        T_NAME_RELATIVE,
       ],
       $stack_ptr - 1,
       NULL,

--- a/tests/Fixtures/VariableNaming.php
+++ b/tests/Fixtures/VariableNaming.php
@@ -14,6 +14,12 @@ class ClassWithMixedVariableNaming {
 
   public static $camelCaseStaticProperty;
 
+  protected ?string $nullableProperty = NULL;
+
+  protected ?\DOMDocument $xmlDom = NULL;
+
+  protected ?\DateTime $dateTime = NULL;
+
   public function methodWithMixedLocalVariables(): void {
     $valid_snake_case_local = 'valid';
     $another_valid_local = 123;
@@ -65,6 +71,7 @@ class ClassWithPromotedProperties {
   public function __construct(
     public string $promotedPropertyOne,
     public string $promoted_property_two,
+    public ?\DOMDocument $promotedNullableProperty = NULL,
   ) {
     $localVar = 'invalid';
     $valid_local = 'valid';

--- a/tests/Unit/AbstractVariableNamingSniffTest.php
+++ b/tests/Unit/AbstractVariableNamingSniffTest.php
@@ -261,6 +261,26 @@ class AbstractVariableNamingSniffTest extends UnitTestCase {
         'bar',
         FALSE,
       ],
+      'typed_property' => [
+        '<?php class Test { protected string $typedProperty; }',
+        'typedProperty',
+        TRUE,
+      ],
+      'nullable_property' => [
+        '<?php class Test { protected ?string $nullableProperty = NULL; }',
+        'nullableProperty',
+        TRUE,
+      ],
+      'nullable_fully_qualified_property' => [
+        '<?php class Test { protected ?\DOMDocument $xmlDom = NULL; }',
+        'xmlDom',
+        TRUE,
+      ],
+      'nullable_qualified_property' => [
+        '<?php namespace App; class Test { protected ?Some\Type $property = NULL; }',
+        'property',
+        TRUE,
+      ],
     ];
   }
 
@@ -327,6 +347,16 @@ class AbstractVariableNamingSniffTest extends UnitTestCase {
         '<?php $variable = 1;',
         'variable',
         FALSE,
+      ],
+      'promoted_nullable_property' => [
+        '<?php class Test { public function __construct(public ?string $property) {} }',
+        'property',
+        TRUE,
+      ],
+      'promoted_nullable_fully_qualified_property' => [
+        '<?php class Test { public function __construct(public ?\DOMDocument $dom) {} }',
+        'dom',
+        TRUE,
       ],
     ];
   }


### PR DESCRIPTION
Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of PHP 8+ namespaced type tokens in property contexts, including support for nullable properties with fully qualified and namespace-qualified types.

* **Tests**
  * Expanded test coverage for typed and nullable property detection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->